### PR TITLE
Allowing p to return a vector instead of a single value

### DIFF
--- a/adaptMCMC/man/MCMC.Rd
+++ b/adaptMCMC/man/MCMC.Rd
@@ -17,7 +17,10 @@ MCMC(p, n, init, scale = rep(1, length(init)),
 
 \arguments{
   \item{p}{
-    function that returns the log probability density to sample from.
+    function that returns the log probability density to sample from. Optionally,
+    the function can return a fixed size numerical vector containing the log
+    probability density as a first element and other values of interest as 
+    subsequent elements, e.g. the log-likelihood value.
   }
   \item{n}{
     number of samples.
@@ -67,7 +70,10 @@ MCMC(p, n, init, scale = rep(1, length(init)),
 
   If \code{list=TRUE} a list is returned with the following components:
   \item{samples}{matrix with samples}
-  \item{log.p}{vector with the (unnormalized) log density for each sample}
+  \item{log.p}{if the function p returns a single number, then a vector with the
+  (unnormalized) log density for each sample; otherwise,  a matrix containing 
+  the (unnormalized) log density as first colum and any other numerical column
+  retured by p.}
   \item{n.sample}{number of generated samples}
   \item{acceptance.rate}{acceptance rate}
   \item{adaption}{either logical if adaption was used or not, or the

--- a/test_adaptMCMC.r
+++ b/test_adaptMCMC.r
@@ -55,7 +55,7 @@ plot(convert.to.coda(samp))
 
 
 samp <- MCMC.parallel(p.log, n, n.chain=5, n.cpu=5, init=rep(0,d),
-                      acc.rate=0.234, adapt=TRUE, packages='mnormt')
+                      acc.rate=0.234, adapt=TRUE, packages='mvtnorm')
 
 means
 


### PR DESCRIPTION
Dear Andreas,

Sorry for my long silence. I've implemented the change we've previously discussed. I'd super happy if this can quickly become part of a new adaptMCMC version on CRAN. Currently, my package POUMM is using a modified version of the MCMC function. It will be ideal if I can simply reference / include the adaptMCMC package.

Commited changes:

1. change to mvtnorm-package to fix failing tests;
2. In MCMC and MCMC.add.samples, return a matrix log.p as element in the returned list (parameter list = TRUE), when the user-specified function p returns a vector instead of a single number.
3. updated documentation

p.s. I haven't updated any metadata in the package (e.g. NAMESPACE and DESCRIPTION).

Cheers, 
Venelin